### PR TITLE
add parenthesis to remove warning during compilation with elixir 1.2.x

### DIFF
--- a/lib/breadcrumble/plugs.ex
+++ b/lib/breadcrumble/plugs.ex
@@ -3,7 +3,7 @@ defmodule Breadcrumble.Plugs do
     breadcrumb = [name: opts[:name], url: opts[:url]]
     trail_index = opts[:index] || 0
     breadcrumb_trails = Map.get(conn.assigns, :breadcrumb_trails, [])
-                        |> update_breadcrumb_trails trail_index, breadcrumb
+                        |> update_breadcrumb_trails(trail_index, breadcrumb)
     %{conn | assigns: Map.put(conn.assigns, :breadcrumb_trails, breadcrumb_trails)}
   end 
 


### PR DESCRIPTION
#### Issue

Warning messages being issued at compile time with elixir 1.2.x

```
lib/breadcrumble/plugs.ex:6: warning: you are piping into a function call without parentheses, which may be ambiguous. Please wrap the function you are piping into in parentheses. For example:

    foo 1 |> bar 2 |> baz 3

Should be written as:

    foo(1) |> bar(2) |> baz(3)
```
#### Solution

Just add parenthesis as suggested in error message. 
