### PR TITLE
Support elixir version 1.9 or later

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -15,6 +15,8 @@ jobs:
         include:
           - elixir: 1.9.4
             otp: 20.3
+          - elixir: 1.9.4
+            otp: 21.3
           - elixir: 1.10.4
             otp: 21.3
           - elixir: 1.11.4
@@ -42,8 +44,6 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
     - name: Install dependencies
       run: mix deps.get
-    - name: clean telemetry first
-      run: mix deps.clean telemetry
     - name: Run tests
       run: mix test
 

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -42,6 +42,8 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
     - name: Install dependencies
       run: mix deps.get
+    - name: compile telemetry
+      run: mix deps.compile telemetry
     - name: Run tests
       run: mix test
 

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir }} # Define the elixir version [required]
         otp-version: ${{ matrix.otp }} # Define the OTP version [required]
@@ -56,7 +56,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir }} # Define the elixir version [required]
         otp-version: ${{ matrix.otp }} # Define the OTP version [required]

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,18 +13,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.7.4
-            otp: 19.3
-          - elixir: 1.8.2
-            otp: 20.3
           - elixir: 1.9.4
             otp: 20.3
-          - elixir: 1.10.3
-            otp: 22.3
-          - elixir: 1.11.2
+          - elixir: 1.10.4
             otp: 21.3
-          - elixir: 1.11.2
-            otp: 23.0
+          - elixir: 1.11.4
+            otp: 21.3
+          - elixir: 1.12.3
+            otp: 22.3
+          - elixir: 1.12.3
+            otp: 23.3
+          - elixir: 1.13.1
+            otp: 23.3
+          - elixir: 1.13.1
+            otp: 24.2
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
@@ -49,8 +51,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.11.2
-            otp: 23.0
+          - elixir: 1.13.1
+            otp: 23.3
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -42,8 +42,8 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
     - name: Install dependencies
       run: mix deps.get
-    - name: compile telemetry
-      run: mix deps.compile telemetry
+    - name: clean telemetry first
+      run: mix deps.clean telemetry
     - name: Run tests
       run: mix test
 

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,6 @@ defmodule Breadcrumble.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:plug, ">= 0.12.0 and < 2.0.0"}, {:power_assert, "~> 0.2.1", only: :test}]
+    [{:plug, ">= 0.12.0 and < 2.0.0"}, {:power_assert, "~> 0.2.1", only: :test}, {:mime, "< 2.0.0"}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -37,9 +37,7 @@ defmodule Breadcrumble.Mixfile do
   defp deps do
     [
       {:plug, ">= 0.12.0 and < 2.0.0"},
-      {:power_assert, "~> 0.2.1", only: :test},
-      {:mime, "< 2.0.0"},
-      {:telemetry, "< 1.0.0"}
+      {:power_assert, "~> 0.2.1", only: :test}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,6 @@ defmodule Breadcrumble.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:plug, ">= 0.12.0 and < 2.0.0"}, {:power_assert, "~> 0.2.1", only: :test}, {:mime, "< 2.0.0"}]
+    [{:plug, ">= 0.12.0 and < 2.0.0"}, {:power_assert, "~> 0.2.1", only: :test}, {:mime, "< 2.0.0"}, {:telemetry, "< 1.0.0"}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,11 @@ defmodule Breadcrumble.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:plug, ">= 0.12.0 and < 2.0.0"}, {:power_assert, "~> 0.2.1", only: :test}, {:mime, "< 2.0.0"}, {:telemetry, "< 1.0.0"}]
+    [
+      {:plug, ">= 0.12.0 and < 2.0.0"},
+      {:power_assert, "~> 0.2.1", only: :test},
+      {:mime, "< 2.0.0"},
+      {:telemetry, "< 1.0.0"}
+    ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Breadcrumble.Mixfile do
     [
       app: :breadcrumble,
       version: "1.0.4",
-      elixir: "~> 1.7",
+      elixir: "~> 1.9",
       description: "Elixir port of Breadcrumble library",
       package: [
         maintainers: ["Takayuki Matsubara"],

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,7 @@
+%{
+  "mime": {:hex, :mime, "1.6.0", "dabde576a497cef4bbdd60aceee8160e02a6c89250d6c0b29e56c0dfb00db3d2", [:mix], [], "hexpm", "31a1a8613f8321143dde1dafc36006a17d28d02bdfecb9e95a880fa7aabd19a7"},
+  "plug": {:hex, :plug, "1.12.1", "645678c800601d8d9f27ad1aebba1fdb9ce5b2623ddb961a074da0b96c35187d", [:mix], [{:mime, "~> 1.0 or ~> 2.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.1.1 or ~> 1.2", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.3 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "d57e799a777bc20494b784966dc5fbda91eb4a09f571f76545b72a634ce0d30b"},
+  "plug_crypto": {:hex, :plug_crypto, "1.2.2", "05654514ac717ff3a1843204b424477d9e60c143406aa94daf2274fdd280794d", [:mix], [], "hexpm", "87631c7ad914a5a445f0a3809f99b079113ae4ed4b867348dd9eec288cecb6db"},
+  "power_assert": {:hex, :power_assert, "0.2.1", "50455767fac8d8dcd312b52bffe9688f83e9100c195b3cb654a38feb67fceeaf", [:mix], [], "hexpm", "f9390f54034ee9fe831647e4ce8b77cf929d30be0517a48bdcac7ee4fac5f6a8"},
+  "telemetry": {:hex, :telemetry, "0.4.3", "a06428a514bdbc63293cd9a6263aad00ddeb66f608163bdec7c8995784080818", [:rebar3], [], "hexpm", "eb72b8365ffda5bed68a620d1da88525e326cb82a75ee61354fc24b844768041"},
+}


### PR DESCRIPTION
- breadcruble supports elixir version 1.9 or later
- upgrade running tests on latest elixir's compatibility
  - see the following:
    - https://hexdocs.pm/elixir/1.13.1/compatibility-and-deprecations.html
    - https://www.erlang.org/downloads
- migrate CI setting to https://github.com/erlef/setup-beam
- add mix.lock to follow the guideline
  - https://hexdocs.pm/elixir/master/library-guidelines.html#dependency-handling
